### PR TITLE
feat: Add generation of types, fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.3",
   "license": "MIT",
   "main": "./lib-node/index_node.js",
+  "types": "./types/index_node.d.ts",
   "module": "./lib/index.js",
   "browser": "./lib/index.js",
   "exports": {
@@ -15,8 +16,9 @@
     "clean-modules": "rm -rf lib",
     "build:node": "tsc -p tsconfig.cjs.json",
     "build:web": "tsc -p tsconfig.esm.json",
-    "build": "npm run clean-modules && npm run build:node && npm run build:web",
-    "test": "node_modules/.bin/ava"
+    "build": "npm run clean-modules && npm run build:node && npm run build:web && npm run generate-types",
+    "test": "node_modules/.bin/ava",
+    "generate-types": "tsc src/*.ts --declaration --emitDeclarationOnly --outDir types"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",
@@ -27,6 +29,7 @@
     "lib",
     "lib-node",
     "src",
+    "types",
     "package.json"
   ]
 }

--- a/test/cjs_initialization.test.cjs
+++ b/test/cjs_initialization.test.cjs
@@ -1,6 +1,6 @@
 const test = require('ava');
 
-const { initialiseResolver, read_file } = require("../lib/index_node.js");
+const { initialiseResolver, read_file } = require("../lib-node/index_node.js");
 
 test('It reads file from file system within read_file using default implementation.', t => {
 

--- a/test/esm_initialization.test.mjs
+++ b/test/esm_initialization.test.mjs
@@ -1,11 +1,11 @@
 /**
- *  Below tests are commented because they require 
+ *  Below tests are commented because they require
  *  "type": "module", in package.json
  *  Seems that both CJS and MJS modes are not going to work.
 */
 import test from 'ava';
 
-import { initialiseResolver, read_file } from "../lib/index.js";
+import { initialiseResolver, read_file } from "../lib-node/index.js";
 
 test('It communicates error when read_file was called before initialiseResolver.', t => {
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,2 @@
+export declare let read_file: (source_id: any) => string;
+export declare function initialiseResolver(resolver: (source_id: String) => string): void;

--- a/types/index_node.d.ts
+++ b/types/index_node.d.ts
@@ -1,0 +1,2 @@
+import { initialiseResolver, read_file } from './index.js';
+export { initialiseResolver, read_file };


### PR DESCRIPTION
# Description

Extension for the package, allows to generate types declarations

## Problem\*

Mocha tests of crate [`wasm`](https://github.com/noir-lang/noir/tree/master/crates/wasm) fail on nodejs platform because the package provides no typings. 

It is a part of fix https://github.com/noir-lang/noir/pull/2387

## Summary\*

Added types generation in building process. Committed types and updated `package.json`. 

## Additional Context

I fixed the tests because the tests fail. 

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
